### PR TITLE
Harden preview_query SQL execution

### DIFF
--- a/scripts/preview_query.py
+++ b/scripts/preview_query.py
@@ -1,39 +1,84 @@
 import os
+import re
 from dune_client.client import DuneClient
 from dotenv import load_dotenv
 import sys
 import pandas as pd
 
-dotenv_path = os.path.join(os.path.dirname(__file__), '..', '.env')
+dotenv_path = os.path.join(os.path.dirname(__file__), "..", ".env")
 load_dotenv(dotenv_path)
 
 dune = DuneClient.from_env()
 
-#get id passed in python script invoke
-id = sys.argv[1]
+ALLOWED_QUERY_PREFIX = re.compile(
+    r"(?is)\A(?:\s|--[^\n]*(?:\n|$)|/\*.*?\*/)*(select|with)\b"
+)
+WRITE_SQL_KEYWORDS = re.compile(
+    r"(?i)\b(insert|update|delete|drop|alter|create|grant|revoke|truncate|merge|call)\b"
+)
 
-queries_path = os.path.join(os.path.dirname(__file__), '..', 'queries')
+
+def build_preview_sql(raw_query_text: str) -> str:
+    normalized_query = raw_query_text.strip()
+    if normalized_query.endswith(";"):
+        normalized_query = normalized_query[:-1].rstrip()
+
+    query_without_comments = re.sub(
+        r"(?s)--[^\n]*(?:\n|$)|/\*.*?\*/",
+        " ",
+        normalized_query,
+    )
+
+    if ";" in query_without_comments:
+        raise ValueError("Only a single SQL statement can be previewed.")
+
+    if not ALLOWED_QUERY_PREFIX.match(normalized_query):
+        raise ValueError("Only SELECT/WITH queries can be previewed.")
+
+    if WRITE_SQL_KEYWORDS.search(query_without_comments):
+        raise ValueError("Only read-only SQL can be previewed.")
+
+    return f"select * from (\n{normalized_query}\n) as preview_query limit 20"
+
+
+if len(sys.argv) < 2:
+    raise SystemExit("Usage: python scripts/preview_query.py <query_id>")
+
+query_id = sys.argv[1].strip()
+if not query_id.isdigit():
+    raise SystemExit("Query id must be numeric.")
+
+queries_path = os.path.join(os.path.dirname(__file__), "..", "queries")
 files = os.listdir(queries_path)
-found_files = [file for file in files if str(id) == file.split('___')[-1].split('.')[0]]
+found_files = [
+    file for file in files if query_id == file.split("___")[-1].split(".")[0]
+]
 
 if len(found_files) != 0:
-    query_file = os.path.join(os.path.dirname(__file__), '..', 'queries', found_files[0])
+    query_file = os.path.join(
+        os.path.dirname(__file__), "..", "queries", found_files[0]
+    )
 
-    print('getting 20 line preview for query {}...'.format(id))
+    print("getting 20 line preview for query {}...".format(query_id))
 
-    with open(query_file, 'r', encoding='utf-8') as file:
+    with open(query_file, "r", encoding="utf-8") as file:
         query_text = file.read()
 
-    print('select * from (\n' + query_text + '\n) limit 20')
+    try:
+        preview_sql = build_preview_sql(query_text)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
-    results = dune.run_sql('select * from (\n' + query_text + '\n) limit 20')
+    print(preview_sql)
+
+    results = dune.run_sql(preview_sql)
     # print(results.result.rows)
     results = pd.DataFrame(data=results.result.rows)
-    print('\n')
+    print("\n")
     print(results)
-    print('\n')
+    print("\n")
     print(results.describe())
-    print('\n')
+    print("\n")
     print(results.info())
 else:
-    print('query id file not found, try again')
+    print("query id file not found, try again")


### PR DESCRIPTION
<!-- dd-meta {"pullId":"000cb6ef-656d-445c-8888-e26865d8997f","source":"chat","resourceId":"d70f2a3b-97e6-40da-b75b-fb875fffc70c","workflowId":"d7c0ec7a-c9b0-4b78-a801-7d7534133c69","codeChangeId":"d7c0ec7a-c9b0-4b78-a801-7d7534133c69","sourceType":"code_security_sast"} -->
## Motivation (WHY)

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/019a12ed0baa79b60858c7368624be4d?panel_event_id=AwAAAZ8iTLpKMgcx0QAAABhBWjhpVExwS0FBQU5ibm9jQ0J5eTlOek8AAAAkZjE5ZjIyNTMtMWJhYS00ZGI1LWE4ZjMtY2U4NDU2ZmYwYTNiAABVrQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDE5YTEyZWQwYmFhNzliNjA4NThjNzM2ODYyNGJlNGR-YmFmYjY1ODM1Mzc3NWZmN2FiYmMwOGRmODhkNjQ0N2U%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fdunequeryrepo%22+%22Potential+SQL+injection%22)

The preview script executed SQL built from file contents without validating statement type or structure. If query text comes from an untrusted or tampered file, this could execute unintended SQL through the Dune API.

## Changes (WHAT)
- Added strict `query_id` input validation (`numeric` only).
- Added `build_preview_sql(...)` to sanitize and validate preview SQL before execution.
- Enforced read-only preview constraints:
  - single statement only
  - statement must begin with `SELECT` or `WITH` (after comments/whitespace)
  - blocked write/DDL keywords (`insert`, `update`, `delete`, `drop`, etc.)
- Switched execution to use the validated `preview_sql` string.

## Testing (HOW verified)
- `python -m py_compile scripts/preview_query.py`
- `ruff format scripts/preview_query.py`
- `ruff check scripts/preview_query.py`

**Is this linked to an existing issue**
No linked issue.

**Fill out the following table describing your edits:**

| Original | Updated | Change | Reasoning |
|---|---|---|---|
| `scripts/preview_query.py` | `scripts/preview_query.py` | Added query-id validation and SQL validation before `run_sql` | Reduces SQL injection risk by allowing only single, read-only `SELECT`/`WITH` statements for preview execution |

**Provide any other context or screenshots that explain or justify the changes above:**

This is a focused security hardening change for the SAST finding at `scripts/preview_query.py:29`.

---

**Note to Contributor:**

Make sure your PR edits the original `query_id.sql` file with the new query text. If you are proposing adding a new query completely, make sure to add it to `queries.yml` and as a file in `/queries` as well.

Thanks for contributing! 🙏

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d70f2a3b-97e6-40da-b75b-fb875fffc70c)

Comment @datadog to request changes